### PR TITLE
reverse the meaning of -n

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 const DefaultSeparator string = `(\s\s+|\t)`
-const Version string = "v1.3.3"
+const Version string = "v1.4.0"
 const MAXPARTS = 2
 
 var DefaultConfigfile = os.Getenv("HOME") + "/.config/tablizer/config"
@@ -66,7 +66,7 @@ type Filter struct {
 // internal config
 type Config struct {
 	Debug          bool
-	NoNumbering    bool
+	Numbering      bool
 	NoHeaders      bool
 	Columns        string
 	UseColumns     []int
@@ -332,10 +332,10 @@ func (conf *Config) PrepareTransposers() error {
 func (conf *Config) CheckEnv() {
 	// check for environment vars, command line flags have precedence,
 	// NO_COLOR is being checked by the color module itself.
-	if !conf.NoNumbering {
-		_, set := os.LookupEnv("T_NO_HEADER_NUMBERING")
+	if !conf.Numbering {
+		_, set := os.LookupEnv("T_HEADER_NUMBERING")
 		if set {
-			conf.NoNumbering = true
+			conf.Numbering = true
 		}
 	}
 
@@ -350,7 +350,7 @@ func (conf *Config) CheckEnv() {
 func (conf *Config) ApplyDefaults() {
 	// mode specific defaults
 	if conf.OutputMode == Yaml || conf.OutputMode == CSV {
-		conf.NoNumbering = true
+		conf.Numbering = false
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,7 +125,7 @@ func Execute() {
 	// options
 	rootCmd.PersistentFlags().BoolVarP(&conf.Debug, "debug", "d", false,
 		"Enable debugging")
-	rootCmd.PersistentFlags().BoolVarP(&conf.NoNumbering, "no-numbering", "n", false,
+	rootCmd.PersistentFlags().BoolVarP(&conf.Numbering, "numbering", "n", false,
 		"Disable header numbering")
 	rootCmd.PersistentFlags().BoolVarP(&conf.NoHeaders, "no-headers", "H", false,
 		"Disable header display")

--- a/cmd/tablizer.go
+++ b/cmd/tablizer.go
@@ -11,7 +11,7 @@ SYNOPSIS
         Operational Flags:
           -c, --columns string              Only show the speficied columns (separated by ,)
           -v, --invert-match                select non-matching rows
-          -n, --no-numbering                Disable header numbering
+          -n, --numbering                   Enable header numbering
           -N, --no-color                    Disable pattern highlighting
           -H, --no-headers                  Disable headers display
           -s, --separator string            Custom field separator
@@ -303,7 +303,7 @@ DESCRIPTION
     influence program behavior. Commandline flags have always precedence
     over environment variables.
 
-    <T_NO_HEADER_NUMBERING> - disable numbering of header fields, like -n.
+    <T_HEADER_NUMBERING> - enable numbering of header fields, like -n.
     <T_COLUMNS> - comma separated list of columns to output, like -c
     <NO_COLORS> - disable colorization of matches, like -N
 
@@ -428,7 +428,7 @@ Usage:
 Operational Flags:
   -c, --columns string              Only show the speficied columns (separated by ,)
   -v, --invert-match                select non-matching rows
-  -n, --no-numbering                Disable header numbering
+  -n, --numbering                   Enable header numbering
   -N, --no-color                    Disable pattern highlighting
   -H, --no-headers                  Disable headers display
   -s, --separator string            Custom field separator

--- a/lib/helpers.go
+++ b/lib/helpers.go
@@ -208,13 +208,13 @@ func numberizeAndReduceHeaders(conf cfg.Config, data *Tabdata) {
 			}
 		}
 
-		if conf.NoNumbering {
-			numberedHeaders = append(numberedHeaders, head)
-			headlen = len(head)
-		} else {
+		if conf.Numbering {
 			numhead := fmt.Sprintf("%s(%d)", head, idx+1)
 			headlen = len(numhead)
 			numberedHeaders = append(numberedHeaders, numhead)
+		} else {
+			numberedHeaders = append(numberedHeaders, head)
+			headlen = len(head)
 		}
 
 		if headlen > maxwidth {

--- a/lib/helpers_test.go
+++ b/lib/helpers_test.go
@@ -216,21 +216,21 @@ func TestNumberizeHeaders(t *testing.T) {
 	}
 
 	var tests = []struct {
-		expect  []string
-		columns []int
-		nonum   bool
+		expect    []string
+		columns   []int
+		numberize bool
 	}{
-		{[]string{"ONE(1)", "TWO(2)", "THREE(3)"}, []int{1, 2, 3}, false},
-		{[]string{"ONE(1)", "TWO(2)"}, []int{1, 2}, false},
-		{[]string{"ONE", "TWO"}, []int{1, 2}, true},
+		{[]string{"ONE(1)", "TWO(2)", "THREE(3)"}, []int{1, 2, 3}, true},
+		{[]string{"ONE(1)", "TWO(2)"}, []int{1, 2}, true},
+		{[]string{"ONE", "TWO"}, []int{1, 2}, false},
 	}
 
 	for _, testdata := range tests {
 		testname := fmt.Sprintf("numberize-headers-columns-%+v-nonum-%t",
-			testdata.columns, testdata.nonum)
+			testdata.columns, testdata.numberize)
 
 		t.Run(testname, func(t *testing.T) {
-			conf := cfg.Config{Columns: "x", UseColumns: testdata.columns, NoNumbering: testdata.nonum}
+			conf := cfg.Config{Columns: "x", UseColumns: testdata.columns, Numbering: testdata.numberize}
 			usedata := data
 			numberizeAndReduceHeaders(conf, &usedata)
 			if !reflect.DeepEqual(usedata.headers, testdata.expect) {

--- a/lib/printer_test.go
+++ b/lib/printer_test.go
@@ -65,7 +65,7 @@ var tests = []struct {
 	sortby    string // empty == default
 	column    int    // sort by this column (numbers start by 1)
 	desc      bool   // sort in descending order, default == ascending
-	nonum     bool   // hide numbering
+	numberize bool   // add header numbering
 	mode      int    // shell, orgtbl, etc. empty == default: ascii
 	usecol    []int  // columns to display, empty == display all
 	usecolstr string // for testname, must match usecol
@@ -73,8 +73,9 @@ var tests = []struct {
 }{
 	// --------------------- Default settings mode tests ``
 	{
-		mode: cfg.ASCII,
-		name: "default",
+		mode:      cfg.ASCII,
+		numberize: true,
+		name:      "default",
 		expect: `
 NAME(1)	DURATION(2)	COUNT(3)	WHEN(4)                    
 beta   	1d10h5m1s  	33      	3/1/2014                  	
@@ -82,8 +83,9 @@ alpha  	4h35m      	170     	2013-Feb-03
 ceta   	33d12h     	9       	06/Jan/2008 15:04:05 -0700`,
 	},
 	{
-		mode: cfg.CSV,
-		name: "csv",
+		mode:      cfg.CSV,
+		numberize: false,
+		name:      "csv",
 		expect: `
 NAME,DURATION,COUNT,WHEN
 beta,1d10h5m1s,33,3/1/2014
@@ -91,8 +93,9 @@ alpha,4h35m,170,2013-Feb-03
 ceta,33d12h,9,06/Jan/2008 15:04:05 -0700`,
 	},
 	{
-		name: "default",
-		mode: cfg.Orgtbl,
+		name:      "orgtbl",
+		numberize: true,
+		mode:      cfg.Orgtbl,
 		expect: `
 +---------+-------------+----------+----------------------------+
 | NAME(1) | DURATION(2) | COUNT(3) |          WHEN(4)           |
@@ -103,8 +106,9 @@ ceta,33d12h,9,06/Jan/2008 15:04:05 -0700`,
 +---------+-------------+----------+----------------------------+`,
 	},
 	{
-		name: "default",
-		mode: cfg.Markdown,
+		name:      "markdown",
+		mode:      cfg.Markdown,
+		numberize: true,
 		expect: `
 | NAME(1) | DURATION(2) | COUNT(3) |          WHEN(4)           |
 |---------|-------------|----------|----------------------------|
@@ -113,18 +117,18 @@ ceta,33d12h,9,06/Jan/2008 15:04:05 -0700`,
 | ceta    | 33d12h      |        9 | 06/Jan/2008 15:04:05 -0700 |`,
 	},
 	{
-		name:  "default",
-		mode:  cfg.Shell,
-		nonum: true,
+		name:      "shell",
+		mode:      cfg.Shell,
+		numberize: false,
 		expect: `
 NAME="beta" DURATION="1d10h5m1s" COUNT="33" WHEN="3/1/2014"
 NAME="alpha" DURATION="4h35m" COUNT="170" WHEN="2013-Feb-03"
 NAME="ceta" DURATION="33d12h" COUNT="9" WHEN="06/Jan/2008 15:04:05 -0700"`,
 	},
 	{
-		name:  "default",
-		mode:  cfg.Yaml,
-		nonum: true,
+		name:      "yaml",
+		mode:      cfg.Yaml,
+		numberize: false,
 		expect: `
 entries:
     - count: 33
@@ -141,8 +145,9 @@ entries:
       when: "06/Jan/2008 15:04:05 -0700"`,
 	},
 	{
-		name: "default",
-		mode: cfg.Extended,
+		name:      "extended",
+		mode:      cfg.Extended,
+		numberize: true,
 		expect: `
     NAME(1): beta
 DURATION(2): 1d10h5m1s
@@ -162,10 +167,11 @@ DURATION(2): 33d12h
 
 	//------------------------ SORT TESTS
 	{
-		name:   "sortbycolumn3",
-		column: 3,
-		sortby: "numeric",
-		desc:   false,
+		name:      "sortbycolumn3",
+		column:    3,
+		sortby:    "numeric",
+		numberize: true,
+		desc:      false,
 		expect: `
 NAME(1)	DURATION(2)	COUNT(3)	WHEN(4)                    
 ceta   	33d12h     	9       	06/Jan/2008 15:04:05 -0700	
@@ -173,10 +179,11 @@ beta   	1d10h5m1s  	33      	3/1/2014
 alpha  	4h35m      	170     	2013-Feb-03`,
 	},
 	{
-		name:   "sortbycolumn4",
-		column: 4,
-		sortby: "time",
-		desc:   false,
+		name:      "sortbycolumn4",
+		column:    4,
+		sortby:    "time",
+		desc:      false,
+		numberize: true,
 		expect: `
 NAME(1)	DURATION(2)	COUNT(3)	WHEN(4)                    
 ceta   	33d12h     	9       	06/Jan/2008 15:04:05 -0700	
@@ -184,10 +191,11 @@ alpha  	4h35m      	170     	2013-Feb-03
 beta   	1d10h5m1s  	33      	3/1/2014`,
 	},
 	{
-		name:   "sortbycolumn2",
-		column: 2,
-		sortby: "duration",
-		desc:   false,
+		name:      "sortbycolumn2",
+		column:    2,
+		sortby:    "duration",
+		numberize: true,
+		desc:      false,
 		expect: `
 NAME(1)	DURATION(2)	COUNT(3)	WHEN(4)                    
 alpha  	4h35m      	170     	2013-Feb-03               	
@@ -199,6 +207,7 @@ ceta   	33d12h     	9       	06/Jan/2008 15:04:05 -0700`,
 	{
 		name:      "usecolumns",
 		usecol:    []int{1, 4},
+		numberize: true,
 		usecolstr: "1,4",
 		expect: `
 NAME(1)	WHEN(4)                    
@@ -209,6 +218,7 @@ ceta   	06/Jan/2008 15:04:05 -0700`,
 	{
 		name:      "usecolumns",
 		usecol:    []int{2},
+		numberize: true,
 		usecolstr: "2",
 		expect: `
 DURATION(2) 
@@ -219,6 +229,7 @@ DURATION(2)
 	{
 		name:      "usecolumns",
 		usecol:    []int{3},
+		numberize: true,
 		usecolstr: "3",
 		expect: `
 COUNT(3) 
@@ -230,6 +241,7 @@ COUNT(3)
 		name:      "usecolumns",
 		column:    0,
 		usecol:    []int{1, 3},
+		numberize: true,
 		usecolstr: "1,3",
 		expect: `
 NAME(1)	COUNT(3) 
@@ -240,6 +252,7 @@ ceta   	9`,
 	{
 		name:      "usecolumns",
 		usecol:    []int{2, 4},
+		numberize: true,
 		usecolstr: "2,4",
 		expect: `
 DURATION(2)	WHEN(4)                    
@@ -251,8 +264,10 @@ DURATION(2)	WHEN(4)
 
 func TestPrinter(t *testing.T) {
 	for _, testdata := range tests {
-		testname := fmt.Sprintf("print-%s-%d-desc-%t-sortby-%s-mode-%d-usecolumns-%s",
-			testdata.name, testdata.column, testdata.desc, testdata.sortby, testdata.mode, testdata.usecolstr)
+		testname := fmt.Sprintf("print-%s-%d-desc-%t-sortby-%s-mode-%d-usecolumns-%s-numberize-%t",
+			testdata.name, testdata.column, testdata.desc, testdata.sortby,
+			testdata.mode, testdata.usecolstr, testdata.numberize)
+
 		t.Run(testname, func(t *testing.T) {
 			// replaces os.Stdout, but we ignore it
 			var writer bytes.Buffer
@@ -262,7 +277,7 @@ func TestPrinter(t *testing.T) {
 				SortDescending: testdata.desc,
 				SortMode:       testdata.sortby,
 				OutputMode:     testdata.mode,
-				NoNumbering:    testdata.nonum,
+				Numbering:      testdata.numberize,
 				UseColumns:     testdata.usecol,
 				NoColor:        true,
 			}

--- a/tablizer.1
+++ b/tablizer.1
@@ -133,8 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "TABLIZER 1"
-.TH TABLIZER 1 "2025-02-23" "1" "User Commands"
-
+.TH TABLIZER 1 "2025-03-06" "1" "User Commands"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -150,7 +149,7 @@ tablizer \- Manipulate tabular output of other programs
 \&    Operational Flags:
 \&      \-c, \-\-columns string              Only show the speficied columns (separated by ,)
 \&      \-v, \-\-invert\-match                select non\-matching rows
-\&      \-n, \-\-no\-numbering                Disable header numbering
+\&      \-n, \-\-numbering                   Enable header numbering
 \&      \-N, \-\-no\-color                    Disable pattern highlighting
 \&      \-H, \-\-no\-headers                  Disable headers display
 \&      \-s, \-\-separator string            Custom field separator
@@ -484,8 +483,8 @@ separated by one space.
 \&\fBtablizer\fR supports  certain environment variables which  use can use
 to  influence   program  behavior.   Commandline  flags   have  always
 precedence over environment variables.
-.IP "<T_NO_HEADER_NUMBERING> \- disable numbering of header fields, like \fB\-n\fR." 4
-.IX Item "<T_NO_HEADER_NUMBERING> - disable numbering of header fields, like -n."
+.IP "<T_HEADER_NUMBERING> \- enable numbering of header fields, like \fB\-n\fR." 4
+.IX Item "<T_HEADER_NUMBERING> - enable numbering of header fields, like -n."
 .PD 0
 .IP "<T_COLUMNS> \- comma separated list of columns to output, like \fB\-c\fR" 4
 .IX Item "<T_COLUMNS> - comma separated list of columns to output, like -c"

--- a/tablizer.pod
+++ b/tablizer.pod
@@ -10,7 +10,7 @@ tablizer - Manipulate tabular output of other programs
     Operational Flags:
       -c, --columns string              Only show the speficied columns (separated by ,)
       -v, --invert-match                select non-matching rows
-      -n, --no-numbering                Disable header numbering
+      -n, --numbering                   Enable header numbering
       -N, --no-color                    Disable pattern highlighting
       -H, --no-headers                  Disable headers display
       -s, --separator string            Custom field separator
@@ -329,7 +329,7 @@ precedence over environment variables.
 
 =over
 
-=item <T_NO_HEADER_NUMBERING> - disable numbering of header fields, like B<-n>.
+=item <T_HEADER_NUMBERING> - enable numbering of header fields, like B<-n>.
 
 =item <T_COLUMNS> - comma separated list of columns to output, like B<-c>
 


### PR DESCRIPTION
Setting `-n` now enables numbered headers, otherwise headers are printed unnumbered by default. The old behavior was annoying and the numbers are not really needed anymore since we can use named headers, like `-c id,name`.