### PR TITLE
add some handy builtin character classes as split separators

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	Version  string = "v1.5.9"
-	MAXPARTS        = 2
+	Version  = "v1.5.9"
+	MAXPARTS = 2
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,7 +123,7 @@ func Execute() {
 		"Use alternating background colors")
 	rootCmd.PersistentFlags().StringVarP(&ShowCompletion, "completion", "", "",
 		"Display completion code")
-	rootCmd.PersistentFlags().StringVarP(&conf.Separator, "separator", "s", cfg.DefaultSeparator,
+	rootCmd.PersistentFlags().StringVarP(&conf.Separator, "separator", "s", cfg.SeparatorTemplates[":default:"],
 		"Custom field separator")
 	rootCmd.PersistentFlags().StringVarP(&conf.Columns, "columns", "c", "",
 		"Only show the speficied columns (separated by ,)")

--- a/cmd/tablizer.go
+++ b/cmd/tablizer.go
@@ -14,7 +14,7 @@ SYNOPSIS
           -n, --numbering                    Enable header numbering
           -N, --no-color                     Disable pattern highlighting
           -H, --no-headers                   Disable headers display
-          -s, --separator <string>           Custom field separator
+          -s, --separator <string>           Custom field separator (maybe char, string or :class:)
           -k, --sort-by <int|name>           Sort by column (default: 1)
           -z, --fuzzy                        Use fuzzy search [experimental]
           -F, --filter <field[!]=reg>        Filter given field with regex, can be used multiple times
@@ -140,6 +140,57 @@ DESCRIPTION
 
     Finally the -d option enables debugging output which is mostly useful
     for the developer.
+
+  SEPARATOR
+    The option -s can be a single character, in which case the CSV parser
+    will be invoked. You can also specify a string as separator. The string
+    will be interpreted as literal string unless it is a valid go regular
+    expression. For example:
+
+        -s '\t{2,}\'
+
+    is being used as a regexp and will match two or more consecutive tabs.
+
+        -s 'foo'
+
+    on the other hand is no regular expression and will be used literally.
+
+    To make live easier, there are a couple of predefined regular
+    expressions, which you can specify as classes:
+
+        * :tab:
+
+        Matches a tab and eats spaces around it.
+
+        * :spaces:
+
+        Matches 2 or more spaces.
+
+        * :pipe:
+
+        Matches a pipe character and eats spaces around it.
+
+        * :default:
+
+        Matches 2 or more spaces or tab. This is the default separator if
+        none is specified.
+
+        * :nonword:
+
+        Matches a non-word character.
+
+        * :nondigit:
+
+        Matches a non-digit character.
+
+        * :special:
+
+        Matches one or more special chars like brackets, dollar sign,
+        slashes etc.
+
+        * :nonprint:
+
+        Matches one or more non-printable characters.
 
   PATTERNS AND FILTERING
     You can reduce the rows being displayed by using one or more regular
@@ -458,7 +509,7 @@ Operational Flags:
   -n, --numbering                    Enable header numbering
   -N, --no-color                     Disable pattern highlighting
   -H, --no-headers                   Disable headers display
-  -s, --separator <string>           Custom field separator
+  -s, --separator <string>           Custom field separator (maybe char, string or :class:)
   -k, --sort-by <int|name>           Sort by column (default: 1)
   -z, --fuzzy                        Use fuzzy search [experimental]
   -F, --filter <field[!]=reg>        Filter given field with regex, can be used multiple times

--- a/lib/printer_test.go
+++ b/lib/printer_test.go
@@ -292,6 +292,7 @@ func TestPrinter(t *testing.T) {
 				conf.UseSortByColumn = []int{testdata.column}
 			}
 
+			conf.Separator = cfg.SeparatorTemplates[":default:"]
 			conf.ApplyDefaults()
 
 			// the test checks the len!

--- a/tablizer.1
+++ b/tablizer.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "TABLIZER 1"
-.TH TABLIZER 1 "2025-10-01" "1" "User Commands"
+.TH TABLIZER 1 "2025-10-09" "1" "User Commands"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -152,7 +152,7 @@ tablizer \- Manipulate tabular output of other programs
 \&      \-n, \-\-numbering                    Enable header numbering
 \&      \-N, \-\-no\-color                     Disable pattern highlighting
 \&      \-H, \-\-no\-headers                   Disable headers display
-\&      \-s, \-\-separator <string>           Custom field separator
+\&      \-s, \-\-separator <string>           Custom field separator (maybe char, string or :class:)
 \&      \-k, \-\-sort\-by <int|name>           Sort by column (default: 1)
 \&      \-z, \-\-fuzzy                        Use fuzzy search [experimental]
 \&      \-F, \-\-filter <field[!]=reg>        Filter given field with regex, can be used multiple times
@@ -293,6 +293,62 @@ Sorts timestamps.
 .PP
 Finally the  \fB\-d\fR option  enables debugging  output which  is mostly
 useful for the developer.
+.SS "\s-1SEPARATOR\s0"
+.IX Subsection "SEPARATOR"
+The option \fB\-s\fR can be a single character, in which case the \s-1CSV\s0
+parser will be invoked. You can also specify a string as
+separator. The string will be interpreted as literal string unless it
+is a valid go regular expression. For example:
+.PP
+.Vb 1
+\&    \-s \*(Aq\et{2,}\e\*(Aq
+.Ve
+.PP
+is being used as a regexp and will match two or more consecutive tabs.
+.PP
+.Vb 1
+\&    \-s \*(Aqfoo\*(Aq
+.Ve
+.PP
+on the other hand is no regular expression and will be used literally.
+.PP
+To make live easier, there are a couple of predefined regular
+expressions, which you can specify as classes:
+.Sp
+.RS 4
+* 		:tab:
+.Sp
+Matches a tab and eats spaces around it.
+.Sp
+*		:spaces:
+.Sp
+Matches 2 or more spaces.
+.Sp
+*		:pipe:
+.Sp
+Matches a pipe character and eats spaces around it.
+.Sp
+*		:default:
+.Sp
+Matches 2 or more spaces or tab. This is the default separator if none
+is specified.
+.Sp
+*		:nonword:
+.Sp
+Matches a non-word character.
+.Sp
+*		:nondigit:
+.Sp
+Matches a non-digit character.
+.Sp
+*		:special:
+.Sp
+Matches one or more special chars like brackets, dollar sign, slashes etc.
+.Sp
+*		:nonprint:
+.Sp
+Matches one or more non-printable characters.
+.RE
 .SS "\s-1PATTERNS AND FILTERING\s0"
 .IX Subsection "PATTERNS AND FILTERING"
 You can reduce  the rows being displayed by using  one or more regular

--- a/tablizer.pod
+++ b/tablizer.pod
@@ -13,7 +13,7 @@ tablizer - Manipulate tabular output of other programs
       -n, --numbering                    Enable header numbering
       -N, --no-color                     Disable pattern highlighting
       -H, --no-headers                   Disable headers display
-      -s, --separator <string>           Custom field separator
+      -s, --separator <string>           Custom field separator (maybe char, string or :class:)
       -k, --sort-by <int|name>           Sort by column (default: 1)
       -z, --fuzzy                        Use fuzzy search [experimental]
       -F, --filter <field[!]=reg>        Filter given field with regex, can be used multiple times
@@ -152,6 +152,64 @@ Sorts timestamps.
 
 Finally the  B<-d> option  enables debugging  output which  is mostly
 useful for the developer.
+
+=head2 SEPARATOR
+
+The option B<-s> can be a single character, in which case the CSV
+parser will be invoked. You can also specify a string as
+separator. The string will be interpreted as literal string unless it
+is a valid go regular expression. For example:
+
+    -s '\t{2,}\'
+
+is being used as a regexp and will match two or more consecutive tabs.
+
+    -s 'foo'
+
+on the other hand is no regular expression and will be used literally.
+
+To make live easier, there are a couple of predefined regular
+expressions, which you can specify as classes:
+
+=over
+
+* 		:tab:      
+
+Matches a tab and eats spaces around it.
+
+*		:spaces:
+
+Matches 2 or more spaces.
+
+*		:pipe:
+
+Matches a pipe character and eats spaces around it.
+
+*		:default:
+
+Matches 2 or more spaces or tab. This is the default separator if none
+is specified.
+
+*		:nonword:
+
+Matches a non-word character.
+
+*		:nondigit:
+
+Matches a non-digit character.
+
+*		:special:
+
+Matches one or more of the following special chars
+
+    [\*\+\-_\(\)\[\]\{\}?\\/<>=&$§':,\^"]+`
+
+*		:nonprint: `[[:^print:]]+`
+
+Matches one or more non-printable characters.
+
+
+=back
 
 =head2 PATTERNS AND FILTERING
 

--- a/tablizer.pod
+++ b/tablizer.pod
@@ -200,11 +200,9 @@ Matches a non-digit character.
 
 *		:special:
 
-Matches one or more of the following special chars
+Matches one or more special chars like brackets, dollar sign, slashes etc.
 
-    [\*\+\-_\(\)\[\]\{\}?\\/<>=&$§':,\^"]+`
-
-*		:nonprint: `[[:^print:]]+`
+*		:nonprint:
 
 Matches one or more non-printable characters.
 


### PR DESCRIPTION
Some examples:
- `-s :tab:` split by tab, surrounding spaces will be eaten
- `-s :pipe:` split by pipe character
- `-s :nonword:` split by one or more non-word characters

For more predefined classes, refer to the manual page.